### PR TITLE
Fix xo lint error

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -346,7 +346,7 @@ function createParser({
       vars: {}
     };
 
-    const re = /@(\w+)[ \t\xA0]*/mg;
+    const re = /@(\w+)[^\S\r\n]*/mg;
     const state = {index: 0, lastIndex: 0, text, usercssData};
 
     // parse

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
       "no-mixed-operators": 0,
       "operator-linebreak": 0,
       "padded-blocks": 0,
+      "prefer-destructuring": 0,
       "quote-props": 0,
       "quotes": [
         2,


### PR DESCRIPTION
Fix lint errors in xo v0.21.0.
```
D:\Dev\parse-usercss>npm-run xo --version && npm-run xo
0.21.0

  lib\parse.js:59:3
  ×   59:3   Use array destructuring.                             prefer-destru
cturing
  ×   71:3   Use array destructuring.                             prefer-destru
cturing
  ×  267:9   Use array destructuring.                             prefer-destru
cturing
  ×  349:16  Use unicode escapes instead of hexadecimal escapes.  unicorn/no-he
x-escape
  ×  357:7   Use array destructuring.                             prefer-destru
cturing

  5 errors

```