### PR TITLE
Add: functional test

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -392,7 +392,9 @@ function createParser({
       } else {
         parseStringToEnd(state);
       }
-      usercssData[state.key] = state.value;
+      if (state.key !== 'var') {
+        usercssData[state.key] = state.value;
+      }
 
       re.lastIndex = state.lastIndex;
     }

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -334,6 +334,9 @@ function createParser({
       parseStringToEnd(state);
     }
     result.default = state.value;
+    if (!state.usercssData.vars) {
+      state.usercssData.vars = {};
+    }
     state.usercssData.vars[result.name] = result;
   }
 
@@ -342,9 +345,7 @@ function createParser({
       throw new TypeError("metadata includes invalid character: '\\r'");
     }
 
-    const usercssData = {
-      vars: {}
-    };
+    const usercssData = {};
 
     const re = /@(\w+)[^\S\r\n]*/mg;
     const state = {index: 0, lastIndex: 0, text, usercssData};

--- a/tests/functional.test.js
+++ b/tests/functional.test.js
@@ -1,0 +1,43 @@
+import test from 'ava';
+import * as usercssMeta from '..';
+
+test('Readme example', t => {
+  const data = usercssMeta.parse(`/* ==UserStyle==
+@name        test
+@namespace   github.com/openstyles/stylus
+@version     0.1.0
+@description my userstyle
+@author      Me
+@var text my-color "Select a color" #123456
+==/UserStyle== */`);
+
+  t.deepEqual(data, {
+    name: 'test',
+    namespace: 'github.com/openstyles/stylus',
+    version: '0.1.0',
+    description: 'my userstyle',
+    author: 'Me',
+    vars: {
+      'my-color': {
+        type: 'text',
+        label: 'Select a color',
+        name: 'my-color',
+        value: null,
+        default: '#123456',
+        options: null
+      }
+    }
+  });
+
+  t.deepEqual(
+    usercssMeta.stringify(data, {alignKeys: true}),
+    `/* ==UserStyle==
+@name        test
+@namespace   github.com/openstyles/stylus
+@version     0.1.0
+@description my userstyle
+@author      Me
+@var         text my-color "Select a color" #123456
+==/UserStyle== */`
+  );
+});

--- a/tests/parser.test.js
+++ b/tests/parser.test.js
@@ -21,8 +21,7 @@ test('Default template', t => {
     namespace: 'github.com/openstyles/stylus',
     version: '0.1.0',
     description: 'my userstyle',
-    author: 'Me',
-    vars: {}
+    author: 'Me'
   });
 });
 


### PR DESCRIPTION
* Fix: `metadata.var` is accidentally assigned.
* Fix: `metadata.vars` should be undefined if the string contains no variables. Does it break Stylus?
