### PR TITLE
fix: Use the browser builtin URL class if it exists

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1,6 +1,16 @@
 'use strict';
 
-const {URL} = require('url');
+let URL = null;
+const urlModule = require('url');
+const isBrowser = typeof window === 'object'
+    && typeof document === 'object'
+    && document.nodeType === 9;
+
+if (isBrowser) {
+  URL = window.URL || urlModule.URL;
+} else {
+  URL = urlModule.URL;
+}
 
 const KNOWN_META = new Set([
   'author',

--- a/package.json
+++ b/package.json
@@ -45,6 +45,10 @@
   "xo": {
     "esnext": true,
     "space": true,
+    "envs": [
+      "node",
+      "browser"
+    ],
     "rules": {
       "capitalized-comments": 0,
       "comma-dangle": 0,


### PR DESCRIPTION
This PR enables this package to use the builtin URL api if it's running in a browser.  
I've also added some configuration to XO so that it now expects the Node + browser context.  

I haven't managed to add tests for the added if statement, because it checks for the existance of the global `window` object, which doesn't exist under Node. If you have any recommendation on how this can be tested in a future proof way, Id be happy to attempt to implement it!