### PR TITLE
Fix: stringify multi-line description

### DIFF
--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -29,10 +29,10 @@ function createStringifier({
         }
       } else if (Array.isArray(value)) {
         for (const subLine of value) {
-          lines.push([key, subLine]);
+          lines.push([key, quoteIfNeeded(subLine)]);
         }
       } else {
-        lines.push([key, value]);
+        lines.push([key, quoteIfNeeded(value)]);
       }
     }
     const maxKeyLength = alignKeys ? Math.max(...lines.map(l => l[0].length)) : 0;
@@ -65,6 +65,13 @@ function stringifyVar(va, format, userStringifyVar, space) {
     }
     return va.default;
   }
+}
+
+function quoteIfNeeded(text) {
+  if (text.includes('\n')) {
+    return JSON.stringify(text);
+  }
+  return text;
 }
 
 function escapeComment(text) {

--- a/tests/parser.test.js
+++ b/tests/parser.test.js
@@ -25,6 +25,26 @@ test('Default template', t => {
   });
 });
 
+test('Unquote', t => {
+  const meta = `/* ==UserStyle==
+@description "foo bar"
+==/UserStyle== */`;
+
+  t.deepEqual(looseParser.parse(meta), {
+    description: 'foo bar'
+  });
+});
+
+test('Unquote multiline', t => {
+  const meta = String.raw`/* ==UserStyle==
+@description "foo\nbar"
+==/UserStyle== */`;
+
+  t.deepEqual(looseParser.parse(meta), {
+    description: 'foo\nbar'
+  });
+});
+
 test('Missing metadata @name', t => {
   const meta = `
 /* ==UserStyle==

--- a/tests/stringifier.test.js
+++ b/tests/stringifier.test.js
@@ -39,6 +39,16 @@ test('Default template align keys', t => {
 ==/UserStyle== */`);
 });
 
+test('Multi-line description', t => {
+  const meta = {
+    description: 'my\nuserstyle'
+  };
+
+  t.is(stringify(meta), String.raw`/* ==UserStyle==
+@description "my\nuserstyle"
+==/UserStyle== */`);
+});
+
 test('var color', t => {
   const meta = {
     vars: {


### PR DESCRIPTION
If the description contains "\n" e.g. "my\ndescription", it would be stringified into:
```css
/* ==UserStyle==
@description my
description
==/UserStyle== */
```
And the second line is dropped while parsing.

This PR converts it into:
```css
/* ==UserStyle==
@description "my\ndescription"
==/UserStyle== */
```
Although `@description` is not designed to use multi-line string.