### PR TITLE
Fix stringify for numbers and arrays

### DIFF
--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -68,12 +68,6 @@ function stringifyVar(va, format, userStringifyVar, space) {
 }
 
 function quoteIfNeeded(text) {
-  if (typeof text === 'number') {
-    text = text.toString();
-  }
-  if (Array.isArray(text)) {
-    return JSON.stringify(text);
-  }
   if (typeof text === 'string' && text.includes('\n')) {
     return JSON.stringify(text);
   }

--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -68,6 +68,12 @@ function stringifyVar(va, format, userStringifyVar, space) {
 }
 
 function quoteIfNeeded(text) {
+  if (typeof text === 'number') {
+    text = text.toString();
+  }
+  if (Array.isArray(text)) {
+    return JSON.stringify(text);
+  }
   if (text.includes('\n')) {
     return JSON.stringify(text);
   }

--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -74,7 +74,7 @@ function quoteIfNeeded(text) {
   if (Array.isArray(text)) {
     return JSON.stringify(text);
   }
-  if (text.includes('\n')) {
+  if (typeof text === 'string' && text.includes('\n')) {
     return JSON.stringify(text);
   }
   return text;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "usercss-meta",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Parse the metadata of usercss used by Stylus extension",
   "license": "MIT",
   "repository": "StylishThemes/parse-usercss",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "usercss-meta",
-  "version": "0.6.1",
+  "version": "0.6.0",
   "description": "Parse the metadata of usercss used by Stylus extension",
   "license": "MIT",
   "repository": "StylishThemes/parse-usercss",

--- a/tests/stringifier.test.js
+++ b/tests/stringifier.test.js
@@ -49,6 +49,16 @@ test('Multi-line description', t => {
 ==/UserStyle== */`);
 });
 
+test('Stringify a number', t => {
+  const meta = {
+    author: 999
+  };
+
+  t.is(stringify(meta), String.raw`/* ==UserStyle==
+@author 999
+==/UserStyle== */`);
+});
+
 test('var color', t => {
   const meta = {
     vars: {


### PR DESCRIPTION
This PR makes `stringify` work with numbers and arrays. Previously, it would throw this error:
```sh
  if (text.includes('\n')) {
           ^

TypeError: text.includes is not a function
```

### Test output

```R
  60 passed
-------------------|----------|----------|----------|----------|-------------------|
File               |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
-------------------|----------|----------|----------|----------|-------------------|
All files          |    98.33 |    94.55 |      100 |    98.31 |                   |
 parse-usercss     |      100 |      100 |      100 |      100 |                   |
  index.js         |      100 |      100 |      100 |      100 |                   |
 parse-usercss/lib |    98.32 |    94.55 |      100 |    98.29 |                   |
  parse.js         |      100 |    98.37 |      100 |      100 |           285,337 |
  stringify.js     |    90.57 |    83.33 |      100 |     90.2 |    15,31,32,72,75 |
-------------------|----------|----------|----------|----------|-------------------|
```

### Test environment

- Linux 4.17.6-1-ARCH x86_64 (Antergos)
- NodeJS v10.1.0

