### PR TITLE
Fix: stringify select in xstyle format

### DIFF
--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -45,7 +45,14 @@ function createStringifier({
 }
 
 function stringifyVar(va, format, userStringifyVar, space) {
-  return `${va.type} ${va.name} ${JSON.stringify(va.label)} ${vaDefault()}`;
+  return `${vaType()} ${va.name} ${JSON.stringify(va.label)} ${vaDefault()}`;
+
+  function vaType() {
+    if (format === 'xstyle' && va.type === 'select') {
+      return 'dropdown';
+    }
+    return va.type;
+  }
 
   function vaDefault() {
     if (Object.prototype.hasOwnProperty.call(userStringifyVar, va.type)) {

--- a/tests/stringifier.test.js
+++ b/tests/stringifier.test.js
@@ -149,6 +149,55 @@ test('var select', t => {
 ==/UserStyle== */`);
 });
 
+test('var select xstyle format', t => {
+  const meta = {
+    vars: {
+      'nav-pos': {
+        type: 'select',
+        name: 'nav-pos',
+        label: 'Navbar pos',
+        options: [
+          {
+            name: 'Top',
+            label: 'Top',
+            value: 'top'
+          },
+          {
+            name: 'Bottom',
+            label: 'Bottom',
+            value: 'bottom'
+          },
+          {
+            name: 'Right',
+            label: 'Right',
+            value: 'right'
+          },
+          {
+            name: 'Left',
+            label: 'Left',
+            value: 'left'
+          },
+        ]
+      }
+    }
+  };
+
+  t.is(stringify(meta, {format: 'xstyle'}), endent`
+    /* ==UserStyle==
+    @advanced dropdown nav-pos "Navbar pos" {
+      Top "Top" <<<EOT
+    top EOT;
+      Bottom "Bottom" <<<EOT
+    bottom EOT;
+      Right "Right" <<<EOT
+    right EOT;
+      Left "Left" <<<EOT
+    left EOT;
+    }
+    ==/UserStyle== */
+  `);
+});
+
 test('var text', t => {
   const meta = {
     vars: {


### PR DESCRIPTION
When stringify the `select` variable, it should produce `@advanced dropdown` instead of `@advanced select`.