### PR TITLE
disable source maps

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -12,7 +12,6 @@ function base({
       format: 'iife',
       name: 'usercssMeta',
       freeze: false,
-      sourcemap: true,
       ...output
     },
     plugins: [


### PR DESCRIPTION
Currently this library shows a warning in devtools console in Chrome, which I have to hide explicitly. Source maps aren't needed in the production build because we can use a non-minified version for the purpose of debugging.

Another way to solve this problem would be to generate an additional map-less file in dist.